### PR TITLE
[PXP-2658] Bump PyYAML to 5.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     install_requires=[
         "cdiserrors~=0.1",
         "cdislogging~=0.1",
-        "PyYAML>=4.2b1",
+        "PyYAML~=5.1",
         "six~=1.0",
     ],
 )


### PR DESCRIPTION
Was already using pyyaml `safe_load()` and using 4.2b1; now just bumping to 5.1 

### Dependency updates
bump pyyaml to 5.1


